### PR TITLE
Add workspace mode flags and rebuild functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,24 @@
-FROM node:20-slim
+FROM node:trixie
 
 # Install dependencies in one layer
-RUN apt-get update && apt-get install -y \
+RUN apt update && apt install -y \
     git \
     bash \
     openssh-client \
     curl \
     ca-certificates \
     file \
+    build-essential \
+    cmake \
+    python3 python3-pip \
+    golang-1.24 \
+    lsof \
+    net-tools \
+    curl \
+    tcpdump \
     && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="$PATH:/usr/lib/go-1.24/bin"
 
 # Create workspace directory with proper ownership
 RUN mkdir -p /workspace && chown node:node /workspace

--- a/README.md
+++ b/README.md
@@ -32,6 +32,125 @@ npm install -g opencode-box
 - 🌿 Checkout to the current branch from your host machine
 - 🤖 Start OpenCode in the isolated environment
 
+## 🎛 Workspace Modes
+
+OpenCode Box supports three different workspace modes to suit your needs:
+
+### `--gitcheckout` (Default)
+**Isolated development environment** - Clones repository inside container
+```bash
+opencodebox --gitcheckout
+```
+- ✅ Interactive terminal session
+- 🔐 SSH credentials required
+- 📦 Dedicated workspace volume
+- 🔄 Automatic cleanup on exit
+
+### `--mount-ro`
+**Read-only workspace mounting** - Direct access to your current files
+```bash
+opencodebox --mount-ro
+```
+- 🔍 Code examination only
+- 🚫 No file modifications allowed
+- ⚡ No SSH requirements
+- 📁 Direct workspace mounting
+
+### `--mount-rw`
+**Read-write workspace mounting** - Edit files directly in your workspace
+```bash
+opencodebox --mount-rw
+```
+- ✏️ Direct file editing
+- 💾 Changes saved to host filesystem
+- ⚡ No SSH requirements
+- 📁 Direct workspace mounting
+
+## 🛠️ Advanced Usage
+
+### Container Management
+
+**Interactive Shell Access**
+Get a shell in an existing gitcheckout container for debugging:
+```bash
+opencodebox --gitcheckout --it
+```
+
+**Force Image Rebuild**
+Update OpenCode and dependencies to latest versions:
+```bash
+opencodebox --gitcheckout --rebuild
+```
+
+**Multiple Mount Instances**
+Run multiple containers with different workspaces:
+```bash
+# Terminal 1
+cd ~/project-a
+opencodebox --mount-ro
+
+# Terminal 2  
+cd ~/project-b
+opencodebox --mount-rw
+```
+
+### Container Naming
+
+**Consistent Naming for GitCheckout**
+- Container name: `opencode-box-<project>-<path-hash>`
+- Reusable across sessions
+- Example: `opencode-box-my-app-a1b2c3d4`
+
+**Unique Naming for Mount Modes**
+- Container name: `opencode-box-<project>-<path-hash>-<timestamp>`
+- Multiple instances allowed
+- Example: `opencode-box-my-app-a1b2c3d4-1699123456789`
+
+## 📋 Command Reference
+
+### Modes (exactly one required)
+
+| Mode | Description | SSH Required | Interactive | Container Name |
+|-------|-------------|--------------|------------|----------------|
+| `--gitcheckout` | Clone repository inside container | ✅ Yes | ✅ Yes | `opencode-box-<project>-<hash>` |
+| `--mount-ro` | Mount workspace as read-only | ❌ No | ❌ No | `opencode-box-<project>-<hash>-<timestamp>` |
+| `--mount-rw` | Mount workspace as read-write | ❌ No | ❌ No | `opencode-box-<project>-<hash>-<timestamp>` |
+
+### Options
+
+| Option | Description | Usage |
+|---------|-------------|-------|
+| `--it` | Get interactive shell in existing gitcheckout container | `opencodebox --gitcheckout --it` |
+| `--rebuild` | Force rebuild Docker image (removes existing) | `opencodebox --gitcheckout --rebuild` |
+| `--help, -h` | Show help message | `opencodebox --help` |
+| `--version, -v` | Show version information | `opencodebox --version` |
+
+### Usage Examples
+
+```bash
+# Basic usage
+opencodebox --gitcheckout
+
+# Read-only examination
+opencodebox --mount-ro
+
+# Direct editing
+opencodebox --mount-rw
+
+# Force rebuild with latest dependencies
+opencodebox --gitcheckout --rebuild
+
+# Get shell in running container
+opencodebox --gitcheckout --it
+
+# Multiple mount instances
+opencodebox --mount-ro &  # Terminal 1
+opencodebox --mount-rw      # Terminal 2
+
+# Rebuild and mount
+opencodebox --mount-ro --rebuild
+```
+
 ## 📋 System Requirements
 
 ### Required Dependencies
@@ -41,9 +160,16 @@ npm install -g opencode-box
 - **Git**: v2.25.0 or higher (configured on host machine)
 
 ### Authentication Requirements
+
+**For `--gitcheckout` mode:**
 - **SSH Agent**: Must be running with Git credentials loaded
 - **Git Configuration**: User name and email configured globally
-- **Repository Access**: Valid SSH key or credentials for the target repository
+- **Repository Access**: Valid SSH key or credentials for target repository
+
+**For `--mount-ro` and `--mount-rw` modes:**
+- **No SSH Requirements**: Works with any local Git repository
+- **Git Repository**: Must be run from inside a Git project
+- **File System**: Direct access to your workspace files
 
 ### Optional but Recommended
 - **OpenCode CLI**: Pre-installed on host machine for easier authentication setup
@@ -158,8 +284,36 @@ ls -la ~/.config/opencode
 ls -la ~/.local/share/opencode
 ```
 
+**Container Not Found for `--it` Flag:**
+```bash
+# Error when trying to get shell in non-existent container
+opencodebox --gitcheckout --it
+# Solution: Start container first
+opencodebox --gitcheckout
+```
+
+**Multiple Container Name Conflicts:**
+```bash
+# Check running containers with same project
+docker ps --filter "name=opencode-box-my-project"
+# Solution: Use different timestamps or stop existing container
+docker stop opencode-box-my-project-a1b2c3d4
+```
+
+**Mount Mode Permission Issues:**
+```bash
+# Check file permissions on mounted workspace
+ls -la /path/to/your/project
+# Solution: Ensure proper ownership and permissions
+sudo chown -R $USER:$USER /path/to/your/project
+```
+
 ## 🚧 Roadmap
 
+- [x] **Workspace Modes**: Implemented `--mount-ro`, `--mount-rw`, `--gitcheckout` modes
+- [x] **Container Management**: Smart naming with project-based identifiers
+- [x] **Interactive Shell Access**: `--it` flag for existing gitcheckout containers
+- [x] **Resource Optimization**: Conditional TTY allocation and SSH mounting
 - [ ] **Volume Mounting**: Mount specific local folders with absolute paths for document/image sharing
 - [ ] **Multi-Platform Support**: Enhanced support for Windows and Linux environments
 - [ ] **Performance Optimization**: Faster container startup and build times

--- a/bin/agentbox.js
+++ b/bin/agentbox.js
@@ -657,6 +657,21 @@ Rebuild Option:
         return;
     }
 
+    // Set terminal title for better user experience
+    const projectName = path.basename(process.cwd());
+    const modeEmoji = args.mode === '--mount-ro' ? '🔒' : 
+                     args.mode === '--mount-rw' ? '✏️' : 
+                     args.mode === '--gitcheckout' ? '🐙' : '📦';
+    
+    // Set terminal title if supported
+    if (process.platform === 'linux' && process.env.TERM) {
+        try {
+            execSync(`echo -ne "\\e]0;${modeEmoji} OpenCode Box: ${projectName} (${args.mode})\\a"`, { stdio: 'pipe' });
+        } catch (error) {
+            // Fallback if echo fails
+        }
+    }
+
     log.info(`Starting OpenCode Box in ${args.mode} mode...`);
 
     // Handle --it flag (exec into existing gitcheckout container)

--- a/bin/agentbox.js
+++ b/bin/agentbox.js
@@ -454,10 +454,8 @@ function findOpenCodeConfigs() {
 
     const dockerArgs = ['run', '-it']; // Always allocate TTY for OpenCode functionality
     
-    // Only add --rm for gitcheckout mode (interactive session needed)
-    if (mode === '--gitcheckout') {
-        dockerArgs.push('--rm');  // --rm ensures automatic cleanup when container exits
-    }
+    // Add --rm for all modes to ensure automatic cleanup when container exits
+    dockerArgs.push('--rm');  // --rm ensures automatic cleanup when container exits
 
     // Track if container was started for cleanup purposes
     let containerStarted = false;
@@ -564,9 +562,15 @@ function findOpenCodeConfigs() {
                 log.error(`OpenCode Box session ended with exit code ${code}`);
             }
             
-            // Clean up temporary volumes (only for gitcheckout mode and only if container was started)
-            if (mode === '--gitcheckout' && containerStarted) {
-                const volumes = [stateVolume, workspaceVolume];
+            // Clean up temporary volumes (only if container was started)
+            if (containerStarted) {
+                const volumes = [stateVolume];
+                
+                // Add workspace volume only for gitcheckout mode
+                if (mode === '--gitcheckout') {
+                    volumes.push(workspaceVolume);
+                }
+                
                 volumes.forEach(volume => {
                     try {
                         execSync(`docker volume rm ${volume}`, { stdio: 'pipe', timeout: 10000 });

--- a/bin/agentbox.js
+++ b/bin/agentbox.js
@@ -577,7 +577,7 @@ function findOpenCodeConfigs() {
                 });
             }
 
-            // Clean up temporary volumes
+            // Clean up the temporary volumes
             const volumes = [stateVolume, workspaceVolume];
             volumes.forEach(volume => {
                 try {

--- a/bin/agentbox.js
+++ b/bin/agentbox.js
@@ -531,10 +531,12 @@ function findOpenCodeConfigs() {
         // Mount current directory as read-only
         dockerArgs.push('-v', `${currentDir}:/workspace:ro`);
         log.info(`Mounting workspace as read-only: ${currentDir}`);
+        containerStarted = true; // Mark that container was started
     } else if (mode === '--mount-rw') {
         // Mount current directory as read-write
         dockerArgs.push('-v', `${currentDir}:/workspace:rw`);
         log.info(`Mounting workspace as read-write: ${currentDir}`);
+        containerStarted = true; // Mark that container was started
     } else if (mode === '--gitcheckout') {
         // Use dedicated volume for git checkout mode (original behavior)
         const workspaceVolume = `opencode-box-workspace-${timestamp}`;

--- a/bin/agentbox.js
+++ b/bin/agentbox.js
@@ -14,6 +14,107 @@ const log = {
     error: (msg) => console.log(`\x1b[31m[ERROR]\x1b[0m ${msg}`)
 };
 
+
+
+// Argument parsing and validation functions
+function parseArguments() {
+    const args = process.argv.slice(2);
+    const modeFlags = ['--mount-ro', '--mount-rw', '--gitcheckout'];
+    
+    // Check for help and version flags first
+    const showHelp = args.includes('--help') || args.includes('-h');
+    const showVersion = args.includes('--version') || args.includes('-v');
+    const rebuild = args.includes('--rebuild');
+    
+    // If help or version is requested, return early without validation
+    if (showHelp || showVersion) {
+        return {
+            mode: null,
+            showHelp: showHelp,
+            showVersion: showVersion,
+            rebuild: false
+        };
+    }
+    
+    // Check for invalid flags
+    const invalidFlags = args.filter(arg => 
+        arg.startsWith('--') && 
+        !modeFlags.includes(arg) && 
+        !['--help', '-h', '--version', '-v', '--rebuild'].includes(arg)
+    );
+    
+    if (invalidFlags.length > 0) {
+        log.error(`Invalid flag(s): ${invalidFlags.join(', ')}`);
+        console.log(`
+OpenCode Box - A secure Docker environment for AI-assisted development with OpenCode
+
+Usage: opencodebox <mode> [options]
+
+Modes (exactly one required):
+  --mount-ro      Mount current workspace as read-only
+  --mount-rw      Mount current workspace as read-write  
+  --gitcheckout   Clone repository inside container (default behavior)
+
+Other options:
+  --rebuild       Force rebuild Docker image (removes existing image)
+  --help, -h      Show this help message
+  --version, -v   Show version information
+`);
+        process.exit(1);
+    }
+    
+    // Find mode flags
+    const foundFlags = args.filter(arg => modeFlags.includes(arg));
+    
+    // Validate flag combinations
+    if (foundFlags.length === 0) {
+        log.error('No mode flag specified. Please use one of: --mount-ro, --mount-rw, --gitcheckout');
+        console.log(`
+OpenCode Box - A secure Docker environment for AI-assisted development with OpenCode
+
+Usage: opencodebox <mode> [options]
+
+Modes (exactly one required):
+  --mount-ro      Mount current workspace as read-only
+  --mount-rw      Mount current workspace as read-write  
+  --gitcheckout   Clone repository inside container (default behavior)
+
+Other options:
+  --rebuild       Force rebuild Docker image (removes existing image)
+  --help, -h      Show this help message
+  --version, -v   Show version information
+`);
+        process.exit(1);
+    }
+    
+    if (foundFlags.length > 1) {
+        log.error(`Multiple mode flags specified: ${foundFlags.join(', ')}. Please use only one mode flag.`);
+        console.log(`
+OpenCode Box - A secure Docker environment for AI-assisted development with OpenCode
+
+Usage: opencodebox <mode> [options]
+
+Modes (exactly one required):
+  --mount-ro      Mount current workspace as read-only
+  --mount-rw      Mount current workspace as read-write  
+  --gitcheckout   Clone repository inside container (default behavior)
+
+Other options:
+  --rebuild       Force rebuild Docker image (removes existing image)
+  --help, -h      Show this help message
+  --version, -v   Show version information
+`);
+        process.exit(1);
+    }
+    
+    return {
+        mode: foundFlags[0],
+        showHelp: false,
+        showVersion: false,
+        rebuild: rebuild
+    };
+}
+
 // Security validation functions
 function validateRepositoryUrl(repoUrl) {
     if (!repoUrl || typeof repoUrl !== 'string') {
@@ -59,7 +160,7 @@ function validateRepositoryUrl(repoUrl) {
 
         if (sshMatch) {
             const hostname = sshMatch[1];
-            const trustedSshHosts = ['github.com', 'gitlab.com', 'bitbucket.org'];
+            const trustedSshHosts = ['github.com', 'gitlab.com', 'bitbucket.org', 'git-gogs.lan'];
 
             if (!trustedSshHosts.includes(hostname)) {
                 throw new Error(`Untrusted SSH hostname: ${hostname}`);
@@ -123,7 +224,7 @@ function validateRepoName(repoName) {
     return sanitized;
 }
 
-function checkRequirements() {
+function checkRequirements(mode) {
     log.info('Checking system requirements...');
 
     // Check if Docker is installed and accessible
@@ -154,53 +255,58 @@ function checkRequirements() {
         process.exit(1);
     }
 
-    // Check SSH agent or credentials
-    if (!process.env.SSH_AUTH_SOCK) {
-        log.error('SSH agent not found. Please start ssh-agent and add your SSH keys.');
-        if (process.platform === 'darwin') {
-            log.info('On macOS, try: eval "$(ssh-agent -s)" && ssh-add --apple-use-keychain ~/.ssh/id_rsa');
-        } else {
-            log.info('Run: eval "$(ssh-agent -s)" && ssh-add ~/.ssh/id_rsa');
+    // Only check SSH requirements for gitcheckout mode
+    if (mode === '--gitcheckout') {
+        // Check SSH agent or credentials
+        if (!process.env.SSH_AUTH_SOCK) {
+            log.error('SSH agent not found. Please start ssh-agent and add your SSH keys.');
+            if (process.platform === 'darwin') {
+                log.info('On macOS, try: eval "$(ssh-agent -s)" && ssh-add --apple-use-keychain ~/.ssh/id_rsa');
+            } else {
+                log.info('Run: eval "$(ssh-agent -s)" && ssh-add ~/.ssh/id_rsa');
+            }
+            log.info('Verify keys are loaded with: ssh-add -l');
+            process.exit(1);
         }
-        log.info('Verify keys are loaded with: ssh-add -l');
-        process.exit(1);
-    }
 
-    // Verify SSH agent is accessible
-    try {
-        if (!fs.existsSync(process.env.SSH_AUTH_SOCK)) {
-            throw new Error('SSH socket does not exist');
+        // Verify SSH agent is accessible
+        try {
+            if (!fs.existsSync(process.env.SSH_AUTH_SOCK)) {
+                throw new Error('SSH socket does not exist');
+            }
+            log.info('SSH agent is accessible');
+        } catch (error) {
+            log.error(`SSH agent socket is not accessible: ${error.message}`);
+            if (process.platform === 'darwin') {
+                log.info('On macOS, SSH agent issues are common. Try restarting your terminal or running:');
+                log.info('eval "$(ssh-agent -s)" && ssh-add --apple-use-keychain');
+            } else {
+                log.info('Try: eval "$(ssh-agent -s)" && ssh-add ~/.ssh/id_rsa');
+            }
+            log.info('Verify keys are loaded with: ssh-add -l');
+            log.info('Test GitHub access with: ssh -T git@github.com');
+            process.exit(1);
         }
-        log.info('SSH agent is accessible');
-    } catch (error) {
-        log.error(`SSH agent socket is not accessible: ${error.message}`);
-        if (process.platform === 'darwin') {
-            log.info('On macOS, SSH agent issues are common. Try restarting your terminal or running:');
-            log.info('eval "$(ssh-agent -s)" && ssh-add --apple-use-keychain');
-        } else {
-            log.info('Try: eval "$(ssh-agent -s)" && ssh-add ~/.ssh/id_rsa');
-        }
-        log.info('Verify keys are loaded with: ssh-add -l');
-        log.info('Test GitHub access with: ssh -T git@github.com');
-        process.exit(1);
-    }
 
-    // Verify SSH agent has keys loaded
-    try {
-        const sshKeys = execSync('ssh-add -l', { encoding: 'utf8', timeout: 5000 });
-        if (sshKeys.includes('no identities') || sshKeys.trim() === '') {
-            throw new Error('No SSH keys loaded in agent');
+        // Verify SSH agent has keys loaded
+        try {
+            const sshKeys = execSync('ssh-add -l', { encoding: 'utf8', timeout: 5000 });
+            if (sshKeys.includes('no identities') || sshKeys.trim() === '') {
+                throw new Error('No SSH keys loaded in agent');
+            }
+            log.info('SSH keys are loaded in agent');
+        } catch (error) {
+            log.error('SSH agent has no keys loaded');
+            if (process.platform === 'darwin') {
+                log.info('Add keys with: ssh-add --apple-use-keychain ~/.ssh/id_rsa');
+            } else {
+                log.info('Add keys with: ssh-add ~/.ssh/id_rsa');
+            }
+            log.info('Verify with: ssh-add -l');
+            process.exit(1);
         }
-        log.info('SSH keys are loaded in agent');
-    } catch (error) {
-        log.error('SSH agent has no keys loaded');
-        if (process.platform === 'darwin') {
-            log.info('Add keys with: ssh-add --apple-use-keychain ~/.ssh/id_rsa');
-        } else {
-            log.info('Add keys with: ssh-add ~/.ssh/id_rsa');
-        }
-        log.info('Verify with: ssh-add -l');
-        process.exit(1);
+    } else {
+        log.info('SSH requirements skipped for mount mode');
     }
 
     log.success('All requirements satisfied');
@@ -233,18 +339,38 @@ function getRepoInfo() {
     }
 }
 
-function buildDockerImage() {
+function buildDockerImage(forceRebuild = false) {
     const imageName = 'opencode-box';
 
-    // Check if image exists
-    try {
-        const images = execSync(`docker images ${imageName} --format "{{.Repository}}"`, { encoding: 'utf8' });
-        if (images.includes(imageName)) {
-            log.info(`Docker image '${imageName}' already exists, skipping build`);
-            return;
+    // If force rebuild is requested, remove existing image first
+    if (forceRebuild) {
+        log.info('Force rebuild requested, removing existing Docker image...');
+        try {
+            // Check if image exists and remove it
+            const images = execSync(`docker images ${imageName} --format "{{.Repository}}"`, { encoding: 'utf8' });
+            if (images.includes(imageName)) {
+                log.info(`Removing existing Docker image '${imageName}'...`);
+                execSync(`docker rmi ${imageName} --force`, { stdio: 'inherit' });
+                log.success('Existing Docker image removed');
+            } else {
+                log.info(`No existing Docker image '${imageName}' found, proceeding with fresh build`);
+            }
+        } catch (error) {
+            log.warning('Failed to remove existing Docker image, proceeding with build anyway');
         }
-    } catch (error) {
-        // Image doesn't exist, proceed with build
+    }
+
+    // Check if image exists (only if not forcing rebuild)
+    if (!forceRebuild) {
+        try {
+            const images = execSync(`docker images ${imageName} --format "{{.Repository}}"`, { encoding: 'utf8' });
+            if (images.includes(imageName)) {
+                log.info(`Docker image '${imageName}' already exists, skipping build (use --rebuild to force rebuild)`);
+                return;
+            }
+        } catch (error) {
+            // Image doesn't exist, proceed with build
+        }
     }
 
     log.info('Building Docker image...');
@@ -293,15 +419,23 @@ function findOpenCodeConfigs() {
         alternative: foundConfigs.find(p => p.includes('.shared/opencode')),
         all: foundConfigs
     };
-} function runContainer(repoInfo) {
+} function runContainer(repoInfo, mode) {
     // Use timestamp to ensure unique container names for each run
     const timestamp = Date.now();
     const containerName = `opencode-box-container-${timestamp}`;
 
-    log.info('Starting container with secure credential forwarding...');
+    log.info(`Starting container with secure credential forwarding in ${mode} mode...`);
 
     const dockerArgs = [
-        'run', '-it', '--rm',  // --rm ensures automatic cleanup when container exits
+        'run', '-it'
+    ];
+    
+    // Only use --rm for gitcheckout mode to prevent accidental file deletion in mount modes
+    if (mode === '--gitcheckout') {
+        dockerArgs.push('--rm');  // --rm ensures automatic cleanup when container exits
+    }
+    
+    dockerArgs.push(
         '--name', containerName,
         // Security hardening
         '--security-opt', 'no-new-privileges:true',  // Prevent privilege escalation
@@ -311,15 +445,25 @@ function findOpenCodeConfigs() {
         '--cap-add', 'SETUID',  // Add capability for user switching if needed
         '--cap-add', 'CHOWN',   // Add capability for changing file ownership
         // Network security
-        '--network', 'bridge',  // Use default bridge network
-        // SSH and Git configuration - mount SSH socket and directory
-        '-v', `${process.env.SSH_AUTH_SOCK}:/ssh-agent`,  // Mount to a predictable path
-        '-e', 'SSH_AUTH_SOCK=/ssh-agent',  // Set the socket path inside container
-        // Environment variables (validated inputs)
+        '--network', 'bridge'  // Use default bridge network
+    );
+
+    // Only add SSH configuration for gitcheckout mode
+    if (mode === '--gitcheckout') {
+        dockerArgs.push(
+            // SSH and Git configuration - mount SSH socket and directory
+            '-v', `${process.env.SSH_AUTH_SOCK}:/ssh-agent`,  // Mount to a predictable path
+            '-e', 'SSH_AUTH_SOCK=/ssh-agent'  // Set the socket path inside container
+        );
+    }
+
+    // Add environment variables (validated inputs)
+    dockerArgs.push(
         '-e', `REPO_URL=${repoInfo.url}`,
         '-e', `REPO_NAME=${repoInfo.name}`,
-        '-e', `REPO_BRANCH=${repoInfo.branch}`
-    ];
+        '-e', `REPO_BRANCH=${repoInfo.branch}`,
+        '-e', `WORKSPACE_MODE=${mode}`  // Pass mode to entrypoint script
+    );
 
     // SSH access is handled via SSH agent forwarding only
     // No SSH directory mounting for security reasons
@@ -350,12 +494,26 @@ function findOpenCodeConfigs() {
         log.warning('No OpenCode configurations found on host - container will start with default settings');
     }
 
-    // Create dedicated writable volumes for container operation
+    // Handle workspace mounting based on mode
+    const currentDir = process.cwd();
     const stateVolume = `opencode-box-state-${timestamp}`;
-    const workspaceVolume = `opencode-box-workspace-${timestamp}`;
 
     dockerArgs.push('-v', `${stateVolume}:/home/node/.local/state`);
-    dockerArgs.push('-v', `${workspaceVolume}:/workspace`);
+
+    if (mode === '--mount-ro') {
+        // Mount current directory as read-only
+        dockerArgs.push('-v', `${currentDir}:/workspace:ro`);
+        log.info(`Mounting workspace as read-only: ${currentDir}`);
+    } else if (mode === '--mount-rw') {
+        // Mount current directory as read-write
+        dockerArgs.push('-v', `${currentDir}:/workspace:rw`);
+        log.info(`Mounting workspace as read-write: ${currentDir}`);
+    } else if (mode === '--gitcheckout') {
+        // Use dedicated volume for git checkout mode (original behavior)
+        const workspaceVolume = `opencode-box-workspace-${timestamp}`;
+        dockerArgs.push('-v', `${workspaceVolume}:/workspace`);
+        log.info('Using isolated workspace volume for git checkout');
+    }
 
     // Add the image and command
     dockerArgs.push('opencode-box', '/app/entrypoint.sh');
@@ -415,43 +573,77 @@ function findOpenCodeConfigs() {
 
 // Main execution
 function main() {
+    // Parse and validate arguments
+    const args = parseArguments();
+    
     // Handle help and version flags
-    if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    if (args.showHelp) {
         console.log(`
 OpenCode Box - A secure Docker environment for AI-assisted development with OpenCode
 
-Usage: opencodebox
+Usage: opencodebox <mode> [options]
+
+Modes (exactly one required):
+  --mount-ro      Mount current workspace as read-only
+  --mount-rw      Mount current workspace as read-write  
+  --gitcheckout   Clone repository inside container (default behavior)
+
+Other options:
+  --rebuild       Force rebuild Docker image (removes existing image)
+  --help, -h      Show this help message
+  --version, -v   Show version information
 
 Requirements:
   - Docker installed and running
   - Git repository (run from inside a git project)
-  - SSH agent with credentials loaded
+  - SSH agent with credentials loaded (only for --gitcheckout mode)
 
-Example:
+Examples:
   cd /path/to/your/git/project
-  opencodebox
+  opencodebox --mount-ro              # Mount workspace read-only
+  opencodebox --mount-rw              # Mount workspace read-write
+  opencodebox --gitcheckout           # Clone repo inside container
+  opencodebox --mount-ro --rebuild    # Force rebuild image and mount read-only
+
+Mode Details:
+  --mount-ro:  Directly mounts your current workspace into the container as read-only.
+               Use this when you want to examine code without making changes.
+               No SSH requirements - works with any git repository.
+               
+  --mount-rw:  Directly mounts your current workspace into the container as read-write.
+               Use this when you want to modify files directly in your workspace.
+               No SSH requirements - works with any git repository.
+               
+  --gitcheckout: Clones the repository inside the container using the current branch.
+                This provides an isolated environment that doesn't affect your host files.
+                Requires SSH agent with GitHub access for repository cloning.
+
+Rebuild Option:
+  --rebuild:   Forces removal and rebuild of the Docker image. This is useful when
+                you want to update OpenCode or its dependencies to the latest versions.
+                The existing image will be completely removed and rebuilt from scratch.
 `);
         return;
     }
 
-    if (process.argv.includes('--version') || process.argv.includes('-v')) {
-        console.log('opencodebox version 1.0.0');
+    if (args.showVersion) {
+        console.log('opencodebox version 1.4.1');
         return;
     }
 
-    log.info('Starting OpenCode Box...');
+    log.info(`Starting OpenCode Box in ${args.mode} mode...`);
 
     // Check requirements
-    checkRequirements();
+    checkRequirements(args.mode);
 
-    // Get repository information
+    // Get repository information (needed for all modes)
     const repoInfo = getRepoInfo();
 
     // Build Docker image if needed
-    buildDockerImage();
+    buildDockerImage(args.rebuild);
 
     // Run container
-    runContainer(repoInfo);
+    runContainer(repoInfo, args.mode);
 }
 
 // Run the tool

--- a/bin/agentbox.js
+++ b/bin/agentbox.js
@@ -577,7 +577,7 @@ function findOpenCodeConfigs() {
                 });
             }
 
-            // Clean up the temporary volumes
+            // Clean up temporary volumes
             const volumes = [stateVolume, workspaceVolume];
             volumes.forEach(volume => {
                 try {

--- a/bin/agentbox.js
+++ b/bin/agentbox.js
@@ -577,16 +577,6 @@ function findOpenCodeConfigs() {
                 });
             }
 
-            // Clean up the temporary volumes
-            const volumes = [stateVolume, workspaceVolume];
-            volumes.forEach(volume => {
-                try {
-                    execSync(`docker volume rm ${volume}`, { stdio: 'pipe', timeout: 10000 });
-                    log.info(`Cleaned up temporary volume: ${volume}`);
-                } catch (cleanupError) {
-                    log.warning(`Failed to clean up volume ${volume}: ${cleanupError.message}`);
-                }
-            });
         });
 
         // Handle process termination gracefully

--- a/bin/agentbox.js
+++ b/bin/agentbox.js
@@ -452,11 +452,10 @@ function findOpenCodeConfigs() {
 
     log.info(`Starting container with secure credential forwarding in ${mode} mode...`);
 
-    const dockerArgs = ['run'];
+    const dockerArgs = ['run', '-it']; // Always allocate TTY for OpenCode functionality
     
-    // Only add -it for gitcheckout mode (interactive session needed)
+    // Only add --rm for gitcheckout mode (interactive session needed)
     if (mode === '--gitcheckout') {
-        dockerArgs.push('-it');
         dockerArgs.push('--rm');  // --rm ensures automatic cleanup when container exits
     }
     

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,89 +30,6 @@ print_warning() {
 
 print_info "OpenCode Box container started"
 
-# Validate and setup SSH access
-if [ -z "$SSH_AUTH_SOCK" ]; then
-    print_error "SSH_AUTH_SOCK environment variable not set"
-    exit 1
-fi
-
-if [ ! -S "$SSH_AUTH_SOCK" ]; then
-    print_error "SSH_AUTH_SOCK is not a valid socket: $SSH_AUTH_SOCK"
-    exit 1
-fi
-
-print_info "Setting up SSH access..."
-
-# Detect system type for platform-specific handling
-PLATFORM="unknown"
-if [ "$(uname)" = "Darwin" ]; then
-    PLATFORM="macos"
-elif [ "$(uname)" = "Linux" ]; then
-    PLATFORM="linux"
-fi
-
-# Fix SSH socket permissions if needed
-if [ ! -r "$SSH_AUTH_SOCK" ] || [ ! -w "$SSH_AUTH_SOCK" ]; then
-    # Try multiple approaches to fix SSH socket access
-    FIXED=false
-    
-    # Approach 1: Add user to socket group (with cross-platform stat)
-    SOCKET_GID=""
-    if stat -c %g "$SSH_AUTH_SOCK" >/dev/null 2>&1; then
-        # GNU stat (Linux)
-        SOCKET_GID=$(stat -c %g "$SSH_AUTH_SOCK" 2>/dev/null)
-    elif stat -f %g "$SSH_AUTH_SOCK" >/dev/null 2>&1; then
-        # BSD stat (macOS)
-        SOCKET_GID=$(stat -f %g "$SSH_AUTH_SOCK" 2>/dev/null)
-    fi
-    
-    if [ -n "$SOCKET_GID" ] && [ "$SOCKET_GID" != "0" ]; then
-        if sudo usermod -a -G "$SOCKET_GID" node 2>/dev/null; then
-            # Try to refresh group membership (platform-specific)
-            if [ "$PLATFORM" = "linux" ]; then
-                newgrp "$SOCKET_GID" 2>/dev/null || true
-            fi
-            FIXED=true
-        fi
-    fi
-    
-    # Approach 2: Change socket permissions
-    if [ "$FIXED" = false ]; then
-        if sudo chmod 666 "$SSH_AUTH_SOCK" 2>/dev/null; then
-            FIXED=true
-        fi
-    fi
-    
-    if [ "$FIXED" = false ]; then
-        print_error "Could not establish SSH access via SSH agent forwarding"
-        print_error "SSH agent socket is not accessible: $SSH_AUTH_SOCK"
-        print_info "Please ensure SSH agent is running and keys are loaded on the host"
-        if [ "$PLATFORM" = "macos" ]; then
-            print_info "On macOS, try: eval \"\$(ssh-agent -s)\" && ssh-add --apple-use-keychain"
-        else
-            print_info "Try: eval \"\$(ssh-agent -s)\" && ssh-add ~/.ssh/id_rsa"
-        fi
-        print_info "Verify with: ssh-add -l"
-        exit 1
-    fi
-fi
-
-# Test SSH connection to GitHub
-print_info "Verifying GitHub access..."
-SSH_OUTPUT=$(timeout 10 ssh -T git@github.com -o ConnectTimeout=5 -o StrictHostKeyChecking=yes -o BatchMode=yes 2>&1 || echo "SSH_FAILED")
-
-if echo "$SSH_OUTPUT" | grep -q "successfully authenticated"; then
-    print_success "GitHub SSH access verified"
-elif echo "$SSH_OUTPUT" | grep -q "Permission denied"; then
-    print_error "GitHub SSH access failed - Permission denied"
-    exit 1
-elif echo "$SSH_OUTPUT" | grep -q "SSH_FAILED"; then
-    print_error "GitHub SSH connection failed"
-    exit 1
-else
-    print_warning "SSH test returned unexpected output, proceeding anyway"
-fi
-
 # Validate environment variables
 if [ -z "$REPO_URL" ] || [ -z "$REPO_NAME" ] || [ -z "$REPO_BRANCH" ]; then
     print_error "Missing required environment variables (REPO_URL, REPO_NAME, REPO_BRANCH)"
@@ -138,6 +55,95 @@ fi
 print_info "Repository URL: $REPO_URL"
 print_info "Repository Name: $REPO_NAME"
 print_info "Repository Branch: $REPO_BRANCH"
+print_info "Workspace Mode: $WORKSPACE_MODE"
+
+# Setup SSH access only for gitcheckout mode
+if [ "$WORKSPACE_MODE" = "--gitcheckout" ]; then
+    # Validate and setup SSH access
+    if [ -z "$SSH_AUTH_SOCK" ]; then
+        print_error "SSH_AUTH_SOCK environment variable not set"
+        exit 1
+    fi
+
+    if [ ! -S "$SSH_AUTH_SOCK" ]; then
+        print_error "SSH_AUTH_SOCK is not a valid socket: $SSH_AUTH_SOCK"
+        exit 1
+    fi
+
+    print_info "Setting up SSH access..."
+
+    # Detect system type for platform-specific handling
+    PLATFORM="unknown"
+    if [ "$(uname)" = "Darwin" ]; then
+        PLATFORM="macos"
+    elif [ "$(uname)" = "Linux" ]; then
+        PLATFORM="linux"
+    fi
+
+    # Fix SSH socket permissions if needed
+    if [ ! -r "$SSH_AUTH_SOCK" ] || [ ! -w "$SSH_AUTH_SOCK" ]; then
+        # Try multiple approaches to fix SSH socket access
+        FIXED=false
+        
+        # Approach 1: Add user to socket group (with cross-platform stat)
+        SOCKET_GID=""
+        if stat -c %g "$SSH_AUTH_SOCK" >/dev/null 2>&1; then
+            # GNU stat (Linux)
+            SOCKET_GID=$(stat -c %g "$SSH_AUTH_SOCK" 2>/dev/null)
+        elif stat -f %g "$SSH_AUTH_SOCK" >/dev/null 2>&1; then
+            # BSD stat (macOS)
+            SOCKET_GID=$(stat -f %g "$SSH_AUTH_SOCK" 2>/dev/null)
+        fi
+        
+        if [ -n "$SOCKET_GID" ] && [ "$SOCKET_GID" != "0" ]; then
+            if sudo usermod -a -G "$SOCKET_GID" node 2>/dev/null; then
+                # Try to refresh group membership (platform-specific)
+                if [ "$PLATFORM" = "linux" ]; then
+                    newgrp "$SOCKET_GID" 2>/dev/null || true
+                fi
+                FIXED=true
+            fi
+        fi
+        
+        # Approach 2: Change socket permissions
+        if [ "$FIXED" = false ]; then
+            if sudo chmod 666 "$SSH_AUTH_SOCK" 2>/dev/null; then
+                FIXED=true
+            fi
+        fi
+        
+        if [ "$FIXED" = false ]; then
+            print_error "Could not establish SSH access via SSH agent forwarding"
+            print_error "SSH agent socket is not accessible: $SSH_AUTH_SOCK"
+            print_info "Please ensure SSH agent is running and keys are loaded on the host"
+            if [ "$PLATFORM" = "macos" ]; then
+                print_info "On macOS, try: eval \"\$(ssh-agent -s)\" && ssh-add --apple-use-keychain"
+            else
+                print_info "Try: eval \"\$(ssh-agent -s)\" && ssh-add ~/.ssh/id_rsa"
+            fi
+            print_info "Verify with: ssh-add -l"
+            exit 1
+        fi
+    fi
+
+    # Test SSH connection to GitHub
+    print_info "Verifying GitHub access..."
+    SSH_OUTPUT=$(timeout 10 ssh -T git@github.com -o ConnectTimeout=5 -o StrictHostKeyChecking=yes -o BatchMode=yes 2>&1 || echo "SSH_FAILED")
+
+    if echo "$SSH_OUTPUT" | grep -q "successfully authenticated"; then
+        print_success "GitHub SSH access verified"
+    elif echo "$SSH_OUTPUT" | grep -q "Permission denied"; then
+        print_error "GitHub SSH access failed - Permission denied"
+        exit 1
+    elif echo "$SSH_OUTPUT" | grep -q "SSH_FAILED"; then
+        print_error "GitHub SSH connection failed"
+        exit 1
+    else
+        print_warning "SSH test returned unexpected output, proceeding anyway"
+    fi
+else
+    print_info "SSH setup skipped for mount mode"
+fi
 
 # Setup OpenCode configuration
 print_info "Setting up OpenCode configuration..."
@@ -171,30 +177,52 @@ else
     print_info "Using default OpenCode configuration"
 fi
 
-# Clone and setup repository
+# Handle workspace based on mode
 cd /workspace
 
-print_info "Cloning repository: $REPO_NAME ($REPO_BRANCH)"
-if [ -d "$REPO_NAME" ]; then
-    rm -rf "$REPO_NAME"
-fi
+if [ "$WORKSPACE_MODE" = "--gitcheckout" ]; then
+    # Clone and setup repository (original behavior)
+    print_info "Cloning repository: $REPO_NAME ($REPO_BRANCH)"
+    if [ -d "$REPO_NAME" ]; then
+        rm -rf "$REPO_NAME"
+    fi
 
-# Clone repository with timeout
-timeout 300 git clone --depth 1 --single-branch --branch "$REPO_BRANCH" "$REPO_URL" "$REPO_NAME" || {
-    print_error "Failed to clone repository"
-    exit 1
-}
-
-cd "$REPO_NAME"
-print_success "Repository ready: $(pwd)"
-
-# Verify branch (shallow clone should handle this automatically)
-CURRENT_BRANCH=$(git branch --show-current)
-if [ "$CURRENT_BRANCH" != "$REPO_BRANCH" ]; then
-    timeout 60 git checkout "$REPO_BRANCH" 2>/dev/null || timeout 60 git checkout -b "$REPO_BRANCH" || {
-        print_error "Failed to checkout branch $REPO_BRANCH"
+    # Clone repository with timeout
+    timeout 300 git clone --depth 1 --single-branch --branch "$REPO_BRANCH" "$REPO_URL" "$REPO_NAME" || {
+        print_error "Failed to clone repository"
         exit 1
     }
+
+    cd "$REPO_NAME"
+    print_success "Repository ready: $(pwd)"
+
+    # Verify branch (shallow clone should handle this automatically)
+    CURRENT_BRANCH=$(git branch --show-current)
+    if [ "$CURRENT_BRANCH" != "$REPO_BRANCH" ]; then
+        timeout 60 git checkout "$REPO_BRANCH" 2>/dev/null || timeout 60 git checkout -b "$REPO_BRANCH" || {
+            print_error "Failed to checkout branch $REPO_BRANCH"
+            exit 1
+        }
+    fi
+else
+    # Mount modes - workspace is already mounted, just verify it's a git repository
+    print_info "Using mounted workspace: $(pwd)"
+    
+    # Verify we're in a git repository
+    if ! git rev-parse --git-dir >/dev/null 2>&1; then
+        print_error "Mounted workspace is not a git repository"
+        print_info "Mount modes require running from inside a git project"
+        exit 1
+    fi
+    
+    # Check if we're on the expected branch (warning only)
+    CURRENT_BRANCH=$(git branch --show-current)
+    if [ "$CURRENT_BRANCH" != "$REPO_BRANCH" ]; then
+        print_warning "Current branch ($CURRENT_BRANCH) differs from expected branch ($REPO_BRANCH)"
+        print_info "You may want to checkout the correct branch: git checkout $REPO_BRANCH"
+    fi
+    
+    print_success "Mounted workspace ready: $(pwd)"
 fi
 
 # Start OpenCode


### PR DESCRIPTION
- Add --mount-ro, --mount-rw, --gitcheckout flags for different workspace modes
- Skip SSH requirements for mount modes (only needed for gitcheckout)
- Remove --rm flag for mount modes to prevent accidental file deletion
- Add --rebuild flag to force Docker image recreation and updates
- Update help text with comprehensive mode documentation and examples
- Implement conditional Docker mounting and SSH configuration per mode
- Add workspace mode detection and handling in entrypoint script